### PR TITLE
Fix repo `bramus/js-specificity` to `bramus/specificity`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bramus/js-specificity.git"
+    "url": "git+https://github.com/bramus/specificity.git"
   },
   "keywords": [
     "css",
@@ -73,9 +73,9 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bramus/js-specificity/issues"
+    "url": "https://github.com/bramus/specificity/issues"
   },
-  "homepage": "https://github.com/bramus/js-specificity#readme",
+  "homepage": "https://github.com/bramus/specificity#readme",
   "devDependencies": {
     "esbuild": "^0.14.5",
     "mocha": "^9.1.3",


### PR DESCRIPTION
I think the repo URL should be <https://github.com/bramus/specificity> now.

If I have misunderstood, feel free to close this PR.