### PR TITLE
Fix `Specificity` type as default

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
 export type SpecificityArray = [number, number, number];
 export type SpecificityObject = { a: number; b: number; c: number };
 
-export class Specificity {
+export default class Specificity {
     static calculate(selector: string | CSSTreeAST): Array<Specificity>;
     static compare(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): number;
     static equals(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): boolean;


### PR DESCRIPTION
This PR fixes the type error of `Specificity` as default. See the following reproduction:

### Reproduction

Given `a.mjs`:

```js
import Specificity from '@bramus/specificity';
console.log(Specificity.calculate('a'));
```

Then run:

```console
$ npm i typescript @bramus/specificity
...

$ npx tsc --checkJs --noEmit a.mjs
a.mjs:1:8 - error TS2613: Module '"/Users/koba/tmp/foo/node_modules/@bramus/specificity/index"' has no default export. Did you mean to use 'import { Specificity } from "/Users/koba/tmp/foo/node_modules/@bramus/specificity/index"' instead?

1 import Specificity from '@bramus/specificity';
         ~~~~~~~~~~~


Found 1 error in a.mjs:1
```

See the implementation:

https://github.com/bramus/specificity/blob/5f98f29718f8050dbe98f2d20788256aa1ad73d3/src/index.js#L124