### PR TITLE
🐛 do not throw when :is/:any/:matches do not contain children

### DIFF
--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -36,13 +36,15 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     case 'any':
                     case 'not':
                     case 'has':
-                        // Calculate Specificity from nested SelectorList
-                        const max1 = max(...calculate(child.children.first));
+                        if (child.children) {
+                            // Calculate Specificity from nested SelectorList
+                            const max1 = max(...calculate(child.children.first));
 
-                        // Adjust orig specificity
-                        specificity.a += max1.a;
-                        specificity.b += max1.b;
-                        specificity.c += max1.c;
+                            // Adjust orig specificity
+                            specificity.a += max1.a;
+                            specificity.b += max1.b;
+                            specificity.c += max1.c;
+                        }
 
                         break;
 

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,21 @@ describe('CALCULATE', () => {
         });
     });
 
+    describe('CSS empty :is, :matches, :any, :where = (0,0,0)', () => {
+        it(':is = (0,0,0)', () => {
+            deepEqual(Specificity.calculate(':is')[0].toObject(), { a: 0, b: 0, c: 0 })
+        })
+        it(':matches = (0,0,0)', () => {
+            deepEqual(Specificity.calculate(':matches')[0].toObject(), { a: 0, b: 0, c: 0 })
+        })
+        it(':any = (0,0,0)', () => {
+            deepEqual(Specificity.calculate(':any')[0].toObject(), { a: 0, b: 0, c: 0 })
+        })
+        it(':where = (0,0,0)', () => {
+            deepEqual(Specificity.calculate(':where')[0].toObject(), { a: 0, b: 0, c: 0 })
+        })
+    })
+
     describe('CSS :has() = Specificity of the most specific complex selector in its selector list argument', () => {
         it(':has(#foo, .bar, baz) = (1,0,0)', () => {
             deepEqual(Specificity.calculate(':has(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });

--- a/test/index.js
+++ b/test/index.js
@@ -143,18 +143,18 @@ describe('CALCULATE', () => {
 
     describe('CSS empty :is, :matches, :any, :where = (0,0,0)', () => {
         it(':is = (0,0,0)', () => {
-            deepEqual(Specificity.calculate(':is')[0].toObject(), { a: 0, b: 0, c: 0 })
-        })
+            deepEqual(Specificity.calculate(':is')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
         it(':matches = (0,0,0)', () => {
-            deepEqual(Specificity.calculate(':matches')[0].toObject(), { a: 0, b: 0, c: 0 })
-        })
+            deepEqual(Specificity.calculate(':matches')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
         it(':any = (0,0,0)', () => {
-            deepEqual(Specificity.calculate(':any')[0].toObject(), { a: 0, b: 0, c: 0 })
-        })
+            deepEqual(Specificity.calculate(':any')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
         it(':where = (0,0,0)', () => {
-            deepEqual(Specificity.calculate(':where')[0].toObject(), { a: 0, b: 0, c: 0 })
-        })
-    })
+            deepEqual(Specificity.calculate(':where')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
+    });
 
     describe('CSS :has() = Specificity of the most specific complex selector in its selector list argument', () => {
         it(':has(#foo, .bar, baz) = (1,0,0)', () => {


### PR DESCRIPTION
This unifies behaviour between empty `:is`/`:any`/`:matches` pseudo-classes.

closes #12