### PR TITLE
Add view-transition specificity calculation

### DIFF
--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -139,6 +139,19 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                         }
                         break;
 
+                    case 'view-transition-group':
+                    case 'view-transition-image-pair':
+                    case 'view-transition-old':
+                    case 'view-transition-new':
+                        // The specificity of a view-transition selector with a * argument is zero.
+                        if (child.children && child.children.first.value === '*') {
+                            break
+                        }
+                        // The specificity of a view-transition selector with an argument is the same
+                        // as for other pseudo - elements, and is equivalent to a type selector.
+                        specificity.c += 1
+                        break;
+
                     default:
                         specificity.c += 1;
                         break;

--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -145,11 +145,11 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     case 'view-transition-new':
                         // The specificity of a view-transition selector with a * argument is zero.
                         if (child.children && child.children.first.value === '*') {
-                            break
+                            break;
                         }
                         // The specificity of a view-transition selector with an argument is the same
                         // as for other pseudo - elements, and is equivalent to a type selector.
-                        specificity.c += 1
+                        specificity.c += 1;
                         break;
 
                     default:

--- a/test/index.js
+++ b/test/index.js
@@ -102,33 +102,33 @@ describe('CALCULATE', () => {
         // Default Specificity is 0,0,1...
         it('::view-transition', () => {
             deepEqual(Specificity.calculate('::view-transition')[0].toObject(), { a: 0, b: 0, c: 1 });
-        })
+        });
         it('::view-transition-group(test)', () => {
             deepEqual(Specificity.calculate('::view-transition-group(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
-        })
+        });
         it('::view-transition-image-pair(test)', () => {
             deepEqual(Specificity.calculate('::view-transition-image-pair(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
-        })
+        });
         it('::view-transition-old(test)', () => {
             deepEqual(Specificity.calculate('::view-transition-old(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
-        })
+        });
         it('::view-transition-new(test)', () => {
             deepEqual(Specificity.calculate('::view-transition-new(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
-        })
+        });
 
         // Specificity is 0,0,0 when name equals *
         it('::view-transition-group(*)', () => {
             deepEqual(Specificity.calculate('::view-transition-group(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
-        })
+        });
         it('::view-transition-image-pair(*)', () => {
             deepEqual(Specificity.calculate('::view-transition-image-pair(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
-        })
+        });
         it('::view-transition-old(*)', () => {
             deepEqual(Specificity.calculate('::view-transition-old(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
-        })
+        });
         it('::view-transition-new(*)', () => {
             deepEqual(Specificity.calculate('::view-transition-new(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
-        })
+        });
     });
 
     // @ref https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#index

--- a/test/index.js
+++ b/test/index.js
@@ -98,6 +98,39 @@ describe('CALCULATE', () => {
         });
     });
 
+    describe('Pseudo-Element Selector ::view-transition and friends', () => {
+        // Default Specificity is 0,0,1...
+        it('::view-transition', () => {
+            deepEqual(Specificity.calculate('::view-transition')[0].toObject(), { a: 0, b: 0, c: 1 });
+        })
+        it('::view-transition-group(test)', () => {
+            deepEqual(Specificity.calculate('::view-transition-group(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
+        })
+        it('::view-transition-image-pair(test)', () => {
+            deepEqual(Specificity.calculate('::view-transition-image-pair(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
+        })
+        it('::view-transition-old(test)', () => {
+            deepEqual(Specificity.calculate('::view-transition-old(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
+        })
+        it('::view-transition-new(test)', () => {
+            deepEqual(Specificity.calculate('::view-transition-new(test)')[0].toObject(), { a: 0, b: 0, c: 1 });
+        })
+
+        // Specificity is 0,0,0 when name equals *
+        it('::view-transition-group(*)', () => {
+            deepEqual(Specificity.calculate('::view-transition-group(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
+        })
+        it('::view-transition-image-pair(*)', () => {
+            deepEqual(Specificity.calculate('::view-transition-image-pair(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
+        })
+        it('::view-transition-old(*)', () => {
+            deepEqual(Specificity.calculate('::view-transition-old(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
+        })
+        it('::view-transition-new(*)', () => {
+            deepEqual(Specificity.calculate('::view-transition-new(*)')[0].toObject(), { a: 0, b: 0, c: 0 });
+        })
+    });
+
     // @ref https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#index
     describe('Pseudo-Class improperly used instead of Pseudo-Element Selector = (0,0,1)', () => {
         it(':before', () => {


### PR DESCRIPTION
Closes https://github.com/bramus/specificity/issues/18

Not sure if this is what you had in mind, but added a bunch of test cases to prove that it works with named groups as well as `*`.