### PR TITLE
perf: save 0.2kB bundle size by const-ing error message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { compare, equals, greaterThan, lessThan } from './util/compare.js';
 import { min, max } from './util/filter.js';
 import { sortAsc, sortDesc } from './util/sort.js';
 
-const SETTER_ERROR_MESSAGE = 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value'
+const SETTER_ERROR_MESSAGE = 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value';
 
 class Specificity {
     constructor(value, selector = null) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@ import { compare, equals, greaterThan, lessThan } from './util/compare.js';
 import { min, max } from './util/filter.js';
 import { sortAsc, sortDesc } from './util/sort.js';
 
-const SETTER_ERROR_MESSAGE = 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value';
+class NotAllowedError extends Error {
+    constructor() {
+        super('Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()');
+    }
+}
 
 class Specificity {
     constructor(value, selector = null) {
@@ -17,7 +21,7 @@ class Specificity {
     }
 
     set a(val) {
-        throw new Error(SETTER_ERROR_MESSAGE);
+        throw new NotAllowedError();
     }
 
     get b() {
@@ -25,7 +29,7 @@ class Specificity {
     }
 
     set b(val) {
-        throw new Error(SETTER_ERROR_MESSAGE);
+        throw new NotAllowedError();
     }
 
     get c() {
@@ -33,7 +37,7 @@ class Specificity {
     }
 
     set c(val) {
-        throw new Error(SETTER_ERROR_MESSAGE);
+        throw new NotAllowedError();
     }
 
     selectorString() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import generate from 'css-tree/generator';
-
 import { calculate } from './core/index.js';
 import { compare, equals, greaterThan, lessThan } from './util/compare.js';
 import { min, max } from './util/filter.js';
 import { sortAsc, sortDesc } from './util/sort.js';
+
+const SETTER_ERROR_MESSAGE = 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value'
+
 class Specificity {
     constructor(value, selector = null) {
         this.value = value;
@@ -15,7 +17,7 @@ class Specificity {
     }
 
     set a(val) {
-        throw new Error('Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value');
+        throw new Error(SETTER_ERROR_MESSAGE);
     }
 
     get b() {
@@ -23,7 +25,7 @@ class Specificity {
     }
 
     set b(val) {
-        throw new Error('Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value');
+        throw new Error(SETTER_ERROR_MESSAGE);
     }
 
     get c() {
@@ -31,7 +33,7 @@ class Specificity {
     }
 
     set c(val) {
-        throw new Error('Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value');
+        throw new Error(SETTER_ERROR_MESSAGE);
     }
 
     selectorString() {

--- a/test/types.js
+++ b/test/types.js
@@ -1,4 +1,4 @@
-import { deepEqual } from 'assert';
+import { deepEqual, throws } from 'assert';
 import Specificity from '../dist/index.js';
 
 describe('Specificity Class, manual instance', () => {
@@ -16,6 +16,38 @@ describe('Specificity Class, manual instance', () => {
         });
         it('Specificity.c', () => {
             deepEqual(s.c, 3);
+        });
+    });
+    describe('Instance Setters', () => {
+        it('Specificity.a', () => {
+            throws(
+                () => {
+                    s.a = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.b', () => {
+            throws(
+                () => {
+                    s.b = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.c', () => {
+            throws(
+                () => {
+                    s.c = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
         });
     });
     describe('Value Formatting', () => {
@@ -59,6 +91,38 @@ describe('Specificity Class, manual instance, no given selector', () => {
             deepEqual(s.c, 3);
         });
     });
+    describe('Instance Setters', () => {
+        it('Specificity.a', () => {
+            throws(
+                () => {
+                    s.a = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.b', () => {
+            throws(
+                () => {
+                    s.b = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.c', () => {
+            throws(
+                () => {
+                    s.c = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+    });
     describe('Value Formatting', () => {
         it('Specificity.toString()', () => {
             deepEqual(s.toString(), '(1,2,3)');
@@ -98,6 +162,38 @@ describe('Specificity Class', () => {
         });
         it('Specificity.c', () => {
             deepEqual(s.c, 3);
+        });
+    });
+    describe('Instance Setters', () => {
+        it('Specificity.a', () => {
+            throws(
+                () => {
+                    s.a = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.b', () => {
+            throws(
+                () => {
+                    s.b = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
+        });
+        it('Specificity.c', () => {
+            throws(
+                () => {
+                    s.c = 1;
+                },
+                {
+                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                }
+            );
         });
     });
     describe('Value Formatting', () => {

--- a/test/types.js
+++ b/test/types.js
@@ -25,7 +25,7 @@ describe('Specificity Class, manual instance', () => {
                     s.a = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -35,7 +35,7 @@ describe('Specificity Class, manual instance', () => {
                     s.b = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -45,7 +45,7 @@ describe('Specificity Class, manual instance', () => {
                     s.c = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -98,7 +98,7 @@ describe('Specificity Class, manual instance, no given selector', () => {
                     s.a = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -108,7 +108,7 @@ describe('Specificity Class, manual instance, no given selector', () => {
                     s.b = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -118,7 +118,7 @@ describe('Specificity Class, manual instance, no given selector', () => {
                     s.c = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -171,7 +171,7 @@ describe('Specificity Class', () => {
                     s.a = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -181,7 +181,7 @@ describe('Specificity Class', () => {
                     s.b = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });
@@ -191,7 +191,7 @@ describe('Specificity Class', () => {
                     s.c = 1;
                 },
                 {
-                    message: 'Manipulating the port of the specificity directly is not allowed. Instead, directly set a new value',
+                    message: 'Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()',
                 }
             );
         });


### PR DESCRIPTION
Not sure if this is something you'd want to merge, feel free to skip, but I was profiling some perf issues at Wallace's bundle sizes and noticed this error string recurring 3 times.

before

```
index.cjs 50619
index.js  50478
```

after

```
index.cjs 50437 (-182B)
index.js  50296 (-182B)
```

It now throws a `NotAllowedError` with the message `Manipulating a Specificity instance is not allowed. Instead, create a new Specificity()`