### PR TITLE
Fix calculation of any pseudo class

### DIFF
--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -28,12 +28,17 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                         // Noop :)
                         break;
 
-                    // “The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the specificity of the most specific complex selector in its selector list argument.“
-                    case 'is':
-                    case 'matches':
                     case '-webkit-any':
                     case '-moz-any':
                     case 'any':
+                        if (child.children) {
+                            specificity.b += 1;
+                        }
+                        break;
+
+                    // “The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the specificity of the most specific complex selector in its selector list argument.“
+                    case 'is':
+                    case 'matches':
                     case 'not':
                     case 'has':
                         if (child.children) {

--- a/test/index.js
+++ b/test/index.js
@@ -162,21 +162,24 @@ describe('CALCULATE', () => {
         });
     });
 
-    describe('CSS :is() - :matches() - :any() = Specificity of the most specific complex selector in its selector list argument', () => {
+    describe('CSS :is() - :matches() = Specificity of the most specific complex selector in its selector list argument', () => {
         it(':is(#foo, .bar, baz) = (1,0,0)', () => {
             deepEqual(Specificity.calculate(':is(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });
         });
         it(':matches(#foo, .bar, baz) = (1,0,0)', () => {
             deepEqual(Specificity.calculate(':matches(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });
         });
-        it(':any(#foo, .bar, baz) = (1,0,0)', () => {
-            deepEqual(Specificity.calculate(':any(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });
+    });
+
+    describe('CSS :any() = (0,1,0)', () => {
+        it(':any(#foo, .bar, baz) = (0,1,0)', () => {
+            deepEqual(Specificity.calculate(':any(#foo, .bar, baz)')[0].toObject(), { a: 0, b: 1, c: 0 });
         });
-        it(':-moz-any(#foo, .bar, baz) = (1,0,0)', () => {
-            deepEqual(Specificity.calculate(':-moz-any(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });
+        it(':-moz-any(#foo, .bar, baz) = (0,1,0)', () => {
+            deepEqual(Specificity.calculate(':-moz-any(#foo, .bar, baz)')[0].toObject(), { a: 0, b: 1, c: 0 });
         });
-        it(':-webkit-any(#foo, .bar, baz) = (1,0,0)', () => {
-            deepEqual(Specificity.calculate(':-webkit-any(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });
+        it(':-webkit-any(#foo, .bar, baz) = (0,1,0)', () => {
+            deepEqual(Specificity.calculate(':-webkit-any(#foo, .bar, baz)')[0].toObject(), { a: 0, b: 1, c: 0 });
         });
     });
 


### PR DESCRIPTION
The specificity of :-moz-any() and :-webkit-any() is always the same as b-level / class-level specificity of 1.

Since :any() is never implemented this can not be tested, yet if it is used at all, is used as equivalent of :-moz-any() and :-webkit-any(). So treating it as having the same specificity calculations.
