### PR TITLE
🏎️ feat: expose `calculateForAST` method

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: "17"
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -52,7 +52,7 @@ jobs:
           node-version: "17"
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -78,7 +78,7 @@ jobs:
           node-version: "17"
 
       - name: Cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export type SpecificityObject = { a: number; b: number; c: number };
 
 export default class Specificity {
     static calculate(selector: string | CSSTreeAST): Array<Specificity>;
+    static calculateForAST(selectorAST: CSSTreeAST): Array<Specificity>;
     static compare(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): number;
     static equals(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): boolean;
     static lessThan(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): boolean;
@@ -41,7 +42,7 @@ type CSSTreeAST = Object; // @TODO: Define shape
 
 // CORE
 export function calculate(selector: string | CSSTreeAST): Array<Specificity>;
-export function calculateSelectorNode(node: CSSTreeAST): { a: number; b: number; c: number; };
+export function calculateForAST(selectorAST: CSSTreeAST): Specificity;
 
 // UTIL: COMPARE
 export function equals(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ type CSSTreeAST = Object; // @TODO: Define shape
 
 // CORE
 export function calculate(selector: string | CSSTreeAST): Array<Specificity>;
+export function calculateSelectorNode(node: CSSTreeAST): { a: number; b: number; c: number; };
 
 // UTIL: COMPARE
 export function equals(s1: SpecificityInstanceOrObject, s2: SpecificityInstanceOrObject): boolean;

--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -4,6 +4,11 @@ import { max } from './../util/index.js';
 
 /** @param {import('css-tree').Selector} selectorAST */
 const calculateForAST = (selectorAST) => {
+    // Quit while you're ahead
+    if (!selectorAST || selectorAST.type !== 'Selector') {
+        throw new TypeError(`Passed in source is not a Selector AST`);
+    }
+
     // https://www.w3.org/TR/selectors-4/#specificity-rules
     let a = 0; /* ID Selectors */
     let b = 0; /* Class selectors, Attributes selectors, and Pseudo-classes */

--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -2,23 +2,22 @@ import parse from 'css-tree/selector-parser';
 import Specificity from '../index.js';
 import { max } from './../util/index.js';
 
-const calculateSpecificityOfSelectorObject = (selectorObj) => {
+/** @param {import('css-tree').Selector} selectorNode */
+const calculateSelectorNode = (selectorNode) => {
     // https://www.w3.org/TR/selectors-4/#specificity-rules
-    const specificity = {
-        a: 0 /* ID Selectors */,
-        b: 0 /* Class selectors, Attributes selectors, and Pseudo-classes */,
-        c: 0 /* Type selectors and Pseudo-elements */,
-    };
+    let a = 0; /* ID Selectors */
+    let b = 0; /* Class selectors, Attributes selectors, and Pseudo-classes */
+    let c = 0; /* Type selectors and Pseudo-elements */
 
-    selectorObj.children.forEach((child) => {
+    selectorNode.children.forEach((child) => {
         switch (child.type) {
             case 'IdSelector':
-                specificity.a += 1;
+                a += 1;
                 break;
 
             case 'AttributeSelector':
             case 'ClassSelector':
-                specificity.b += 1;
+                b += 1;
                 break;
 
             case 'PseudoClassSelector':
@@ -46,9 +45,9 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                             const max1 = max(...calculate(child.children.first));
 
                             // Adjust orig specificity
-                            specificity.a += max1.a;
-                            specificity.b += max1.b;
-                            specificity.c += max1.c;
+                            a += max1.a;
+                            b += max1.b;
+                            c += max1.c;
                         }
 
                         break;
@@ -56,16 +55,16 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     // “The specificity of an :nth-child() or :nth-last-child() selector is the specificity of the pseudo class itself (counting as one pseudo-class selector) plus the specificity of the most specific complex selector in its selector list argument”
                     case 'nth-child':
                     case 'nth-last-child':
-                        specificity.b += 1;
+                        b += 1;
 
                         if (child.children && child.children.first.selector) {
                             // Calculate Specificity from SelectorList
                             const max2 = max(...calculate(child.children.first.selector));
 
                             // Adjust orig specificity
-                            specificity.a += max2.a;
-                            specificity.b += max2.b;
-                            specificity.c += max2.c;
+                            a += max2.a;
+                            b += max2.b;
+                            c += max2.c;
                         }
                         break;
 
@@ -73,7 +72,7 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     // “The specificity of :host-context() is that of a pseudo-class, plus the specificity of its argument.”
                     case 'host-context':
                     case 'host':
-                        specificity.b += 1;
+                        b += 1;
 
                         if (child.children) {
                             // Workaround to a css-tree bug in which it allows complex selectors instead of only compound selectors
@@ -93,9 +92,9 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                             const childSpecificity = calculate(childAST)[0];
 
                             // Adjust orig specificity
-                            specificity.a += childSpecificity.a;
-                            specificity.b += childSpecificity.b;
-                            specificity.c += childSpecificity.c;
+                            a += childSpecificity.a;
+                            b += childSpecificity.b;
+                            c += childSpecificity.c;
                         }
                         break;
 
@@ -105,11 +104,11 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     case 'before':
                     case 'first-letter':
                     case 'first-line':
-                        specificity.c += 1;
+                        c += 1;
                         break;
 
                     default:
-                        specificity.b += 1;
+                        b += 1;
                         break;
                 }
                 break;
@@ -118,7 +117,7 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                 switch (child.name) {
                     // “The specificity of ::slotted() is that of a pseudo-element, plus the specificity of its argument.”
                     case 'slotted':
-                        specificity.c += 1;
+                        c += 1;
 
                         if (child.children) {
                             // Workaround to a css-tree bug in which it allows complex selectors instead of only compound selectors
@@ -138,9 +137,9 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                             const childSpecificity = calculate(childAST)[0];
 
                             // Adjust orig specificity
-                            specificity.a += childSpecificity.a;
-                            specificity.b += childSpecificity.b;
-                            specificity.c += childSpecificity.c;
+                            a += childSpecificity.a;
+                            b += childSpecificity.b;
+                            c += childSpecificity.c;
                         }
                         break;
 
@@ -154,11 +153,11 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                         }
                         // The specificity of a view-transition selector with an argument is the same
                         // as for other pseudo - elements, and is equivalent to a type selector.
-                        specificity.c += 1;
+                        c += 1;
                         break;
 
                     default:
-                        specificity.c += 1;
+                        c += 1;
                         break;
                 }
                 break;
@@ -172,7 +171,7 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
 
                 // “Ignore the universal selector”
                 if (typeSelector !== '*') {
-                    specificity.c += 1;
+                    c += 1;
                 }
                 break;
 
@@ -182,7 +181,7 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
         }
     });
 
-    return new Specificity(specificity, selectorObj);
+    return { a, b, c };
 };
 
 const convertToAST = (source) => {
@@ -222,6 +221,10 @@ const convertToAST = (source) => {
     throw new TypeError(`Passed in source is not a String nor an Object. I don't know what to do with it.`);
 };
 
+/**
+ * @param {string} selector
+ * @returns {Specificity[]}
+ */
 const calculate = (selector) => {
     // Quit while you're ahead
     if (!selector) {
@@ -234,7 +237,7 @@ const calculate = (selector) => {
 
     // Selector?
     if (ast.type === 'Selector') {
-        return [calculateSpecificityOfSelectorObject(selector)];
+        return [new Specificity(calculateSelectorNode(selector), selector)];
     }
 
     // SelectorList?
@@ -242,11 +245,11 @@ const calculate = (selector) => {
     if (ast.type === 'SelectorList') {
         const specificities = [];
         ast.children.forEach((selector) => {
-            const specificity = calculateSpecificityOfSelectorObject(selector);
+            const specificity = new Specificity(calculateSelectorNode(selector), selector);
             specificities.push(specificity);
         });
         return specificities;
     }
 };
 
-export { calculate };
+export { calculate, calculateSelectorNode };

--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -2,14 +2,14 @@ import parse from 'css-tree/selector-parser';
 import Specificity from '../index.js';
 import { max } from './../util/index.js';
 
-/** @param {import('css-tree').Selector} selectorNode */
-const calculateSelectorNode = (selectorNode) => {
+/** @param {import('css-tree').Selector} selectorAST */
+const calculateForAST = (selectorAST) => {
     // https://www.w3.org/TR/selectors-4/#specificity-rules
     let a = 0; /* ID Selectors */
     let b = 0; /* Class selectors, Attributes selectors, and Pseudo-classes */
     let c = 0; /* Type selectors and Pseudo-elements */
 
-    selectorNode.children.forEach((child) => {
+    selectorAST.children.forEach((child) => {
         switch (child.type) {
             case 'IdSelector':
                 a += 1;
@@ -181,7 +181,7 @@ const calculateSelectorNode = (selectorNode) => {
         }
     });
 
-    return { a, b, c };
+    return new Specificity({ a, b, c }, selectorAST);
 };
 
 const convertToAST = (source) => {
@@ -237,7 +237,7 @@ const calculate = (selector) => {
 
     // Selector?
     if (ast.type === 'Selector') {
-        return [new Specificity(calculateSelectorNode(selector), selector)];
+        return [calculateForAST(selector)];
     }
 
     // SelectorList?
@@ -245,11 +245,11 @@ const calculate = (selector) => {
     if (ast.type === 'SelectorList') {
         const specificities = [];
         ast.children.forEach((selector) => {
-            const specificity = new Specificity(calculateSelectorNode(selector), selector);
+            const specificity = calculateForAST(selector);
             specificities.push(specificity);
         });
         return specificities;
     }
 };
 
-export { calculate, calculateSelectorNode };
+export { calculate, calculateForAST };

--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -30,7 +30,7 @@ const calculateSelectorNode = (selectorNode) => {
                     case '-webkit-any':
                     case 'any':
                         if (child.children) {
-                            specificity.b += 1;
+                            b += 1;
                         }
                         break;
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,1 +1,1 @@
-export { calculate, calculateSelectorNode } from './calculate.js';
+export { calculate, calculateForAST } from './calculate.js';

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,1 +1,1 @@
-export { calculate } from './calculate.js';
+export { calculate, calculateSelectorNode } from './calculate.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import generate from 'css-tree/generator';
-import { calculate } from './core/index.js';
+
+import { calculate, calculateSelectorNode } from './core/index.js';
 import { compare, equals, greaterThan, lessThan } from './util/compare.js';
 import { min, max } from './util/filter.js';
 import { sortAsc, sortDesc } from './util/sort.js';
@@ -92,6 +93,10 @@ class Specificity {
 
     static calculate(selector) {
         return calculate(selector);
+    }
+
+    static calculateSelectorNode(selector) {
+        return calculateSelectorNode(selector);
     }
 
     static compare(s1, s2) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import generate from 'css-tree/generator';
 
-import { calculate, calculateSelectorNode } from './core/index.js';
+import { calculate, calculateForAST } from './core/index.js';
 import { compare, equals, greaterThan, lessThan } from './util/compare.js';
 import { min, max } from './util/filter.js';
 import { sortAsc, sortDesc } from './util/sort.js';
@@ -95,8 +95,8 @@ class Specificity {
         return calculate(selector);
     }
 
-    static calculateSelectorNode(selector) {
-        return calculateSelectorNode(selector);
+    static calculateForAST(selector) {
+        return calculateForAST(selector);
     }
 
     static compare(s1, s2) {

--- a/test/index.js
+++ b/test/index.js
@@ -280,37 +280,37 @@ describe('CALCULATE', () => {
     });
 });
 
-describe('CALCULATE_SELECTOR_NODE', () => {
+describe('CALCULATE_FOR_SELECTOR_AST', () => {
     describe('Examples from the spec', () => {
         it('* = (0,0,0)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('*', { context: 'selector' })), { a: 0, b: 0, c: 0 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('*', { context: 'selector' })).toObject(), { a: 0, b: 0, c: 0 });
         });
         it('li = (0,0,1)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('li', { context: 'selector' })), { a: 0, b: 0, c: 1 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('li', { context: 'selector' })).toObject(), { a: 0, b: 0, c: 1 });
         });
         it('ul li = (0,0,2)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('ul li', { context: 'selector' })), { a: 0, b: 0, c: 2 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('ul li', { context: 'selector' })).toObject(), { a: 0, b: 0, c: 2 });
         });
         it('UL OL+LI  = (0,0,3)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('UL OL+LI ', { context: 'selector' })), { a: 0, b: 0, c: 3 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('UL OL+LI ', { context: 'selector' })).toObject(), { a: 0, b: 0, c: 3 });
         });
         it('H1 + *[REL=up] = (0,1,1)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('H1 + *[REL=up]', { context: 'selector' })), { a: 0, b: 1, c: 1 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('H1 + *[REL=up]', { context: 'selector' })).toObject(), { a: 0, b: 1, c: 1 });
         });
         it('UL OL LI.red = (0,1,3)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('UL OL LI.red', { context: 'selector' })), { a: 0, b: 1, c: 3 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('UL OL LI.red', { context: 'selector' })).toObject(), { a: 0, b: 1, c: 3 });
         });
         it('LI.red.level = (0,2,1)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('LI.red.level', { context: 'selector' })), { a: 0, b: 2, c: 1 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('LI.red.level', { context: 'selector' })).toObject(), { a: 0, b: 2, c: 1 });
         });
         it('#x34y = (1,0,0)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('#x34y', { context: 'selector' })), { a: 1, b: 0, c: 0 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('#x34y', { context: 'selector' })).toObject(), { a: 1, b: 0, c: 0 });
         });
         it('#s12:not(FOO) = (1,0,1)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('#s12:not(FOO)', { context: 'selector' })), { a: 1, b: 0, c: 1 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('#s12:not(FOO)', { context: 'selector' })).toObject(), { a: 1, b: 0, c: 1 });
         });
         it('.foo :is(.bar, #baz) = (1,1,0)', () => {
-            deepEqual(Specificity.calculateSelectorNode(csstree.parse('.foo :is(.bar, #baz)', { context: 'selector' })), { a: 1, b: 1, c: 0 });
+            deepEqual(Specificity.calculateForAST(csstree.parse('.foo :is(.bar, #baz)', { context: 'selector' })).toObject(), { a: 1, b: 1, c: 0 });
         });
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 import { deepEqual } from 'assert';
 import Specificity from '../dist/index.js';
+import * as csstree from 'css-tree';
 
 describe('CALCULATE', () => {
     describe('Examples from the spec', () => {
@@ -275,6 +276,41 @@ describe('CALCULATE', () => {
     describe('Calculate handles nesting selectors', () => {
         it('& = (0,0,0)', () => {
             deepEqual(Specificity.calculate('&')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
+    });
+});
+
+describe('CALCULATE_SELECTOR_NODE', () => {
+    describe('Examples from the spec', () => {
+        it('* = (0,0,0)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('*', { context: 'selector' })), { a: 0, b: 0, c: 0 });
+        });
+        it('li = (0,0,1)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('li', { context: 'selector' })), { a: 0, b: 0, c: 1 });
+        });
+        it('ul li = (0,0,2)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('ul li', { context: 'selector' })), { a: 0, b: 0, c: 2 });
+        });
+        it('UL OL+LI  = (0,0,3)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('UL OL+LI ', { context: 'selector' })), { a: 0, b: 0, c: 3 });
+        });
+        it('H1 + *[REL=up] = (0,1,1)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('H1 + *[REL=up]', { context: 'selector' })), { a: 0, b: 1, c: 1 });
+        });
+        it('UL OL LI.red = (0,1,3)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('UL OL LI.red', { context: 'selector' })), { a: 0, b: 1, c: 3 });
+        });
+        it('LI.red.level = (0,2,1)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('LI.red.level', { context: 'selector' })), { a: 0, b: 2, c: 1 });
+        });
+        it('#x34y = (1,0,0)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('#x34y', { context: 'selector' })), { a: 1, b: 0, c: 0 });
+        });
+        it('#s12:not(FOO) = (1,0,1)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('#s12:not(FOO)', { context: 'selector' })), { a: 1, b: 0, c: 1 });
+        });
+        it('.foo :is(.bar, #baz) = (1,1,0)', () => {
+            deepEqual(Specificity.calculateSelectorNode(csstree.parse('.foo :is(.bar, #baz)', { context: 'selector' })), { a: 1, b: 1, c: 0 });
         });
     });
 });

--- a/test/standalone.js
+++ b/test/standalone.js
@@ -1,7 +1,7 @@
 import { deepEqual } from 'assert';
 import * as csstree from 'css-tree';
 
-import { calculate } from './../src/core/index.js';
+import { calculate, calculateSelectorNode } from './../src/core/index.js';
 import { compare, equals, greaterThan, lessThan } from './../src/util/compare.js';
 import { min, max } from './../src/util/filter.js';
 import { sortAsc, sortDesc } from './../src/util/sort.js';
@@ -47,6 +47,24 @@ describe('STANDALONE CACULATE WITH PREPARSED AST', () => {
         deepEqual(calculate(selectors[1])[0].toObject(), { a: 0, b: 2, c: 0 });
         deepEqual(calculate(selectors[2])[0].toObject(), { a: 0, b: 0, c: 1 });
     });
+});
+
+describe('STANDALONE CACULATE_SELECTOR_NODE', () => {
+    const css = `
+        html #test, .class[cool] {
+            color: red;
+        }
+        foo {
+            background: lime;
+        }
+    `;
+
+    const ast = csstree.parse(css);
+    const selectors = csstree.findAll(ast, (node) => node.type === 'Selector');
+
+    deepEqual(calculateSelectorNode(selectors[0]), { a: 1, b: 0, c: 1 });
+    deepEqual(calculateSelectorNode(selectors[1]), { a: 0, b: 2, c: 0 });
+    deepEqual(calculateSelectorNode(selectors[2]), { a: 0, b: 0, c: 1 });
 });
 
 describe('STANDALONE COMPARE', () => {

--- a/test/standalone.js
+++ b/test/standalone.js
@@ -1,7 +1,7 @@
 import { deepEqual } from 'assert';
 import * as csstree from 'css-tree';
 
-import { calculate, calculateSelectorNode } from './../src/core/index.js';
+import { calculate, calculateForAST } from './../src/core/index.js';
 import { compare, equals, greaterThan, lessThan } from './../src/util/compare.js';
 import { min, max } from './../src/util/filter.js';
 import { sortAsc, sortDesc } from './../src/util/sort.js';
@@ -49,9 +49,10 @@ describe('STANDALONE CACULATE WITH PREPARSED AST', () => {
     });
 });
 
-describe('STANDALONE CACULATE_SELECTOR_NODE', () => {
+describe('STANDALONE CACULATE_FOR_SELECTOR_AST', () => {
     const css = `
-        html #test, .class[cool] {
+        html #test,
+        .class[cool] {
             color: red;
         }
         foo {
@@ -62,9 +63,9 @@ describe('STANDALONE CACULATE_SELECTOR_NODE', () => {
     const ast = csstree.parse(css);
     const selectors = csstree.findAll(ast, (node) => node.type === 'Selector');
 
-    deepEqual(calculateSelectorNode(selectors[0]), { a: 1, b: 0, c: 1 });
-    deepEqual(calculateSelectorNode(selectors[1]), { a: 0, b: 2, c: 0 });
-    deepEqual(calculateSelectorNode(selectors[2]), { a: 0, b: 0, c: 1 });
+    deepEqual(calculateForAST(selectors[0]).toObject(), { a: 1, b: 0, c: 1 });
+    deepEqual(calculateForAST(selectors[1]).toObject(), { a: 0, b: 2, c: 0 });
+    deepEqual(calculateForAST(selectors[2]).toObject(), { a: 0, b: 0, c: 1 });
 });
 
 describe('STANDALONE COMPARE', () => {

--- a/test/standalone.js
+++ b/test/standalone.js
@@ -50,22 +50,32 @@ describe('STANDALONE CACULATE WITH PREPARSED AST', () => {
 });
 
 describe('STANDALONE CACULATE_FOR_SELECTOR_AST', () => {
-    const css = `
-        html #test,
-        .class[cool] {
-            color: red;
+    it('trows an error if called without a selector', () => {
+        try {
+            calculateForAST();
+        } catch (error) {
+            deepEqual(error.message, 'Passed in source is not a Selector AST');
         }
-        foo {
-            background: lime;
-        }
-    `;
+    });
 
-    const ast = csstree.parse(css);
-    const selectors = csstree.findAll(ast, (node) => node.type === 'Selector');
+    it('calculates specificity', () => {
+        const css = `
+            html #test,
+            .class[cool] {
+                color: red;
+            }
+            foo {
+                background: lime;
+            }
+        `;
 
-    deepEqual(calculateForAST(selectors[0]).toObject(), { a: 1, b: 0, c: 1 });
-    deepEqual(calculateForAST(selectors[1]).toObject(), { a: 0, b: 2, c: 0 });
-    deepEqual(calculateForAST(selectors[2]).toObject(), { a: 0, b: 0, c: 1 });
+        const ast = csstree.parse(css);
+        const selectors = csstree.findAll(ast, (node) => node.type === 'Selector');
+
+        deepEqual(calculateForAST(selectors[0]).toObject(), { a: 1, b: 0, c: 1 });
+        deepEqual(calculateForAST(selectors[1]).toObject(), { a: 0, b: 2, c: 0 });
+        deepEqual(calculateForAST(selectors[2]).toObject(), { a: 0, b: 0, c: 1 });
+    });
 });
 
 describe('STANDALONE COMPARE', () => {


### PR DESCRIPTION
closes #17 

- [x] Exposes `calculateSelectorNode` next to the existing `calculate` function
- [x] Adds static `Specificity.calculateSelectorNode(selector: string)` + tests
- [x] Moved around some internals so `calculateSelectorNode` does not need to reference `Specificity` each time
- [x] Agree on naming
- [x] Check that `/test/standalone` is implemented correcty. I suspect the existing tests for `calculate` don't actually test it's implementation so I did mine a little different than the existing tests. Please double-check my work 😅. Also opened #24 for further discussion.