### PR TITLE
Add test case for `&` selector

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -259,6 +259,12 @@ describe('CALCULATE', () => {
             deepEqual(Specificity.calculate(''), []);
         });
     });
+
+    describe('Calculate handles nesting selectors', () => {
+        it('& = (0,0,0)', () => {
+            deepEqual(Specificity.calculate('&')[0].toObject(), { a: 0, b: 0, c: 0 });
+        });
+    });
 });
 
 describe('COMPARE', () => {


### PR DESCRIPTION
Based on https://github.com/w3c/csswg-drafts/issues/10287 we need to have an explicit test to see if the specificity for a single `&` is correct. This commit adds that test.

Closes #26