### PR TITLE
💥 do not crash when `nth-(last-)-child` has no children

### DIFF
--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -58,7 +58,7 @@ const calculateSpecificityOfSelectorObject = (selectorObj) => {
                     case 'nth-last-child':
                         specificity.b += 1;
 
-                        if (child.children.first.selector) {
+                        if (child.children && child.children.first.selector) {
                             // Calculate Specificity from SelectorList
                             const max2 = max(...calculate(child.children.first.selector));
 

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,17 @@ describe('CALCULATE', () => {
         it(':focus', () => {
             deepEqual(Specificity.calculate(':focus')[0].toObject(), { a: 0, b: 1, c: 0 });
         });
+        it('p:nth-child(1) = (0,1,1)', () => {
+            deepEqual(Specificity.calculate('p:nth-child(1)')[0].toObject(), { a: 0, b: 1, c: 1 });
+        });
+        it('p:nth-child(2n+1) = (0,1,1)', () => {
+            deepEqual(Specificity.calculate('p:nth-child(2n+1)')[0].toObject(), { a: 0, b: 1, c: 1 });
+        });
+        it('p:nth-child = (0,1,1) & do not crash', () => {
+            deepEqual(Specificity.calculate('p:nth-child')[0].toObject(), { a: 0, b: 1, c: 1 });
+        });
     });
+
 
     describe('CSS :is(), :matches(), :-moz-any = Specificity of the most specific complex selector in its selector list argument', () => {
         it(':is(#foo, .bar, baz) = (1,0,0)', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -171,7 +171,6 @@ describe('CALCULATE', () => {
         });
     });
 
-
     describe('CSS :is(), :matches(), :-moz-any = Specificity of the most specific complex selector in its selector list argument', () => {
         it(':is(#foo, .bar, baz) = (1,0,0)', () => {
             deepEqual(Specificity.calculate(':is(#foo, .bar, baz)')[0].toObject(), { a: 1, b: 0, c: 0 });


### PR DESCRIPTION
Came across this in the wild, so figured it's worth fixing because the same check exists for all other scenarios too.